### PR TITLE
ci: build wasm in Cloudflare Pages, drop wasm/pkg from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .direnv
 node_modules
+/wasm/pkg
+/wasm/target

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "prettier --check .",
-    "deploy": "cd web && pnpm install && NODE_OPTIONS=--experimental-wasm-modules pnpm run build"
+    "deploy": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --target wasm32-unknown-unknown && . \"$HOME/.cargo/env\" && pnpm install && pnpm exec wasm-pack build --release wasm && rm -f wasm/pkg/.gitignore && cd web && pnpm install && NODE_OPTIONS=--experimental-wasm-modules pnpm run build"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Stop committing `wasm/pkg` (added to `.gitignore`)
- Root `deploy` script now installs rustup + builds `wasm-pack` output before the web build, so Cloudflare Pages produces the wasm itself
- Requires Cloudflare Pages build image v3 (Node 22)

## Test plan
- [x] Cloudflare Pages build green on `cf-build-test` with build image v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)